### PR TITLE
Uncommented line to fix calculation of Collection stats

### DIFF
--- a/LucindriSearcher/src/main/java/org/lemurproject/lucindri/searcher/IndriIndexSearcher.java
+++ b/LucindriSearcher/src/main/java/org/lemurproject/lucindri/searcher/IndriIndexSearcher.java
@@ -40,7 +40,7 @@ public class IndriIndexSearcher extends IndexSearcher {
 					continue;
 				}
 				docCount += terms.getDocCount();
-				// sumTotalTermFreq += terms.getSumTotalTermFreq();
+				sumTotalTermFreq += terms.getSumTotalTermFreq();
 				// System.out.println("Number of tokens (lucene): " +
 				// terms.getSumTotalTermFreq());
 				sumDocFreq += terms.getSumDocFreq();


### PR DESCRIPTION
Search failed with this exception from Lucene: "sumTotalTermFreq must be at least sumDocFreq, sumTotalTermFreq: " in CollectionStatistics.java